### PR TITLE
[Feat] Button 및 Header 공통 컴포넌트 구현 및 스타일 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.17",
+        "pretendard": "^1.3.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.4.1",
@@ -6551,6 +6552,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.17",
+    "pretendard": "^1.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.4.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,11 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import './App.css';
 import Home from './pages/Home';
 import { GlobalStyle } from './styles/globalStyle';
+import './index.css';
 
 function App() {
   return (
-    <div className="w-[470px] min-h-screen flex flex-col bg-black relative mx-auto">
+    <div className="w-[470px] min-h-screen flex flex-col bg-white relative mx-auto">
       <GlobalStyle />
       <Router>
         <Routes>

--- a/src/assets/images/allow-left.svg
+++ b/src/assets/images/allow-left.svg
@@ -1,0 +1,4 @@
+<svg width="11" height="20" viewBox="0 0 11 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.16406 9.91992L10 1.00022" stroke="black" stroke-width="2" stroke-linecap="round"/>
+<path d="M1 10.0801L9.83594 18.9998" stroke="black" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type ButtonProps = {
+  text: string;
+  height?: string;
+  width?: string;
+};
+
+const Button = ({
+  text,
+  height = 'h-[52px]',
+  width = 'w-[420px]',
+}: ButtonProps) => {
+  return (
+    <button
+      className={`flex items-center justify-center rounded-[10px] bg-mainBlue px-4 ${height} ${width}`}
+    >
+      <span className="text-white text-center font-sans text-[16px] font-bold leading-none">
+        {text}
+      </span>
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type ButtonProps = {
   text: string;
   height?: string;
@@ -13,7 +11,7 @@ const Button = ({
 }: ButtonProps) => {
   return (
     <button
-      className={`flex items-center justify-center rounded-[10px] bg-mainBlue px-4 ${height} ${width}`}
+      className={`ml-6 flex items-center justify-center rounded-[10px] bg-mainBlue px-4 ${height} ${width}`}
     >
       <span className="text-white text-center font-sans text-[16px] font-bold leading-none">
         {text}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,22 @@
+import allow from '../assets/images/allow-left.svg';
+
+type HeaderProps = {
+  title?: string;
+};
+
+const Header = ({ title }: HeaderProps) => {
+  return (
+    <>
+      <div className="flex items-center justify-between py-[43px] px-[24px]">
+        <img src={allow} alt="뒤로가기" className="w-6 h-6" />
+        {title && (
+          <span className="flex-1 text-center text-black text-[24px] font-normal leading-[120%] -ml-6">
+            {title}
+          </span>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default Header;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Home = () => {
-  return <h1>홈 페이지입니다ddddddd</h1>;
+  return <></>;
 };
 
 export default Home;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 / @type {import('tailwindcss').Config} */;
 module.exports = {
-  content: ['./index.html', './src//*.{js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       screens: {
@@ -8,11 +8,7 @@ module.exports = {
         xl: '1300px',
       },
       fontFamily: {
-        sans: ['Noto Sans KR'],
-        title: ['Parkinsans'],
-        //Ubuntu
-        //Righteous
-        // Parkinsans
+        sans: ['Pretendard', 'sans-serif'],
       },
       colors: {
         mainBlue: '#275AEC', // 메인 블루


### PR DESCRIPTION
## #️⃣ 이슈 번호

Closes: #7

## 💻 작업 내용

### 🔹 Button 컴포넌트
- 텍스트, width, height를 props로 받아 유연하게 재사용 가능

### 🔹 Header 컴포넌트
- 타이틀은 props로 받고, 기본값은 없음 (optional)

### 🔹 글로벌 Pretendard 적용
- CDN을 통해 Pretendard 폰트 import

![image](https://github.com/user-attachments/assets/0c94ac60-8571-439c-a355-618574f1500b)
