### PR TITLE
✨ [Feat] 전자문서 목록 페이지 구현 및 스타일 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Language from './pages/language/Language';
 import Add from './pages/add/Add';
 import Splash from './pages/splash/Splash';
 import Chat from './pages/chat/Chat';
+import DocList from './pages/docList/DocList';
 
 function FooterCondition() {
   const location = useLocation();
@@ -34,6 +35,7 @@ function App() {
           <Route path="/home" element={<Home />} />
           <Route path="/chatlist" element={<ChatList />} />
           <Route path="/chat" element={<Chat />} />
+          <Route path="/doclist" element={<DocList />} />
         </Routes>
         <FooterCondition />
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,8 +17,8 @@ const Footer = () => {
       navigate('/');
     } else if (menu === 'chatlist') {
       navigate('/chatlist');
-    } else if (menu === 'book') {
-      navigate('/book');
+    } else if (menu === 'doclist') {
+      navigate('/doclist');
     } else if (menu === 'account') {
       navigate('/account');
     }
@@ -64,13 +64,13 @@ const Footer = () => {
       </button>
       <button
         className="flex flex-col gap-1  items-center"
-        onClick={() => handleCLick('book')}
+        onClick={() => handleCLick('doclist')}
       >
-        {isClicked === 'book' ? <BlueBookIcon /> : <BookIcon />}
+        {isClicked === 'doclist' ? <BlueBookIcon /> : <BookIcon />}
 
         <p
           className={`${
-            isClicked === 'book' ? 'text-[#275AEC]' : 'text-[#B2B3B5]'
+            isClicked === 'doclist' ? 'text-[#275AEC]' : 'text-[#B2B3B5]'
           } font-bold text-sm pt-[1.5px]`}
         >
           산재처리

--- a/src/pages/docList/DocBox.tsx
+++ b/src/pages/docList/DocBox.tsx
@@ -1,0 +1,39 @@
+import Box from '@/components/Box';
+
+const DocBox = () => {
+  const handleClick = () => {
+    console.log('전자문서 상세페이지로 이동');
+  };
+  const isSuccess = false;
+
+  return (
+    <div className="flex flex-col gap-4 px-4 h-screen">
+      <p className="flex items-start text-xl font-bold px-4">
+        최근 신청한 산재 목록
+      </p>
+      <div className="flex flex-col gap-4 px-4 h-[30rem] overflow-y-auto pb-4 pt-1">
+        <Box className="flex gap-4 ">
+          <div className="flex flex-col flex-[7] items-start justify-center gap-2 p-4">
+            <p className="font-semibold text-[18px]">출퇴근 재해</p>
+            <p className="line-clamp-1 font-semibold text-mainGray">25.03.24</p>
+          </div>
+          <div className="flex flex-[3] p-4 justify-end items-center">
+            <button
+              onClick={() => handleClick()}
+              className={`${
+                isSuccess ? 'bg-mainGray' : 'bg-mainBlue'
+              } py-2 px-5 rounded-xl`}
+            >
+              {isSuccess ? (
+                <p className="text-white font-semibold text-sm">처리완료</p>
+              ) : (
+                <p className="text-white font-semibold text-sm">처리중</p>
+              )}
+            </button>
+          </div>
+        </Box>
+      </div>
+    </div>
+  );
+};
+export default DocBox;

--- a/src/pages/docList/DocList.tsx
+++ b/src/pages/docList/DocList.tsx
@@ -1,0 +1,22 @@
+import DocBox from './DocBox';
+import AddIcon from '@assets/images/Chat/Add.svg?react';
+import { useNavigate } from 'react-router-dom';
+
+const DocList = () => {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    navigate('/doc');
+  };
+  return (
+    <div className="flex flex-col h-screen gap-4">
+      <div className="flex flex-col py-10 gap-4 justify-between items-center h-[30%] bg-[#CADCFF] rounded-b-3xl ">
+        <p className="font-bold text-2xl">토닥과 쉽게 산재를 신청해보세요.</p>
+        <button onClick={() => handleClick()}>
+          <AddIcon width={90} />
+        </button>
+      </div>
+      <DocBox />
+    </div>
+  );
+};
+export default DocList;


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #25 

## 💻 작업 내용
1. 채팅 목록 페이지 화면 구현
- DocList.tsx
  - AI 챗봇 시작 메시지와 채팅 시작 버튼 구현
  - 버튼 클릭 시 콘솔 로그를 통한 페이지 이동 시뮬레이션

- DocBox.tsx
  - 최근 분석 결과 목록 마크업 및 스크롤 영역 구현
    - 고정 높이, overflow-y-auto 적용
  - 아이콘 버튼 클릭 시 분석 페이지 이동 콘솔 로그 처리

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="469" alt="image" src="https://github.com/user-attachments/assets/d2307948-cb44-4980-8e86-3080013bf1bb" />

## 💬 리뷰 요구사항(선택)