### PR TITLE
✨ [Feat] 전자문서 상세페이지 다국어 지원 구현

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -102,5 +102,31 @@
       }
     },
     "logout": "Logout"
+  },
+  "docDetail": {
+    "completed": "Completed",
+    "back": "Back",
+    "section": {
+      "victim": "Victim Information",
+      "company": "Workplace Information",
+      "injury": "Injury and Treatment Information"
+    },
+    "label": {
+      "name": "Name",
+      "id": "Alien Registration No.",
+      "phone": "Phone Number",
+      "gender": "Gender",
+      "workerType": "Worker Type",
+      "address": "Address",
+      "companyId": "Business ID",
+      "ceo": "Business Owner",
+      "companyName": "Company Name",
+      "type": "Type",
+      "date": "Date and Time",
+      "part": "Injured Part",
+      "hospital": "Hospital",
+      "treatmentType": "Treatment Type",
+      "detail": "Details of the Accident"
+    }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -101,5 +101,31 @@
       }
     },
     "logout": "로그아웃"
+  },
+  "docDetail": {
+    "completed": "처리완료",
+    "back": "이전으로",
+    "section": {
+      "victim": "재해자 정보",
+      "company": "사업장 정보",
+      "injury": "재해 및 치료 정보"
+    },
+    "label": {
+      "name": "이름",
+      "id": "외국인등록번호",
+      "phone": "연락처",
+      "gender": "성별",
+      "workerType": "근로자유형",
+      "address": "거주지",
+      "companyId": "사업장관리번호",
+      "ceo": "사업주명",
+      "companyName": "사업장명",
+      "type": "유형",
+      "date": "발생일시",
+      "part": "다친 부위",
+      "hospital": "의료기관",
+      "treatmentType": "치료 구분",
+      "detail": "재해발생 경위"
+    }
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -101,5 +101,31 @@
       }
     },
     "logout": "Đăng xuất"
+  },
+  "docDetail": {
+    "completed": "Hoàn tất",
+    "back": "Quay lại",
+    "section": {
+      "victim": "Thông tin người bị tai nạn",
+      "company": "Thông tin nơi làm việc",
+      "injury": "Thông tin tai nạn và điều trị"
+    },
+    "label": {
+      "name": "Tên",
+      "id": "Số ĐKNN",
+      "phone": "Số điện thoại",
+      "gender": "Giới tính",
+      "workerType": "Loại lao động",
+      "address": "Địa chỉ",
+      "companyId": "Mã quản lý DN",
+      "ceo": "Chủ doanh nghiệp",
+      "companyName": "Tên công ty",
+      "type": "Loại",
+      "date": "Thời gian xảy ra",
+      "part": "Bộ phận bị thương",
+      "hospital": "Bệnh viện",
+      "treatmentType": "Phương pháp điều trị",
+      "detail": "Chi tiết tai nạn"
+    }
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -102,5 +102,31 @@
       }
     },
     "logout": "退出登录"
+  },
+  "docDetail": {
+    "completed": "处理完成",
+    "back": "返回",
+    "section": {
+      "victim": "受害者信息",
+      "company": "工作场所信息",
+      "injury": "事故与治疗信息"
+    },
+    "label": {
+      "name": "姓名",
+      "id": "外国人登录号",
+      "phone": "联系电话",
+      "gender": "性别",
+      "workerType": "工作类型",
+      "address": "地址",
+      "companyId": "事业场所编号",
+      "ceo": "雇主姓名",
+      "companyName": "事业场所名称",
+      "type": "类型",
+      "date": "事故时间",
+      "part": "受伤部位",
+      "hospital": "医院",
+      "treatmentType": "治疗类型",
+      "detail": "事故经过"
+    }
   }
 }

--- a/src/pages/docList/DocDetail.tsx
+++ b/src/pages/docList/DocDetail.tsx
@@ -3,30 +3,35 @@ import SectionCard from './SectionCard';
 import InfoList from './InfoList';
 import { companyInfo, injuryInfo, jehaejaInfo } from './DocItem';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 const DocDetail = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   return (
     <>
       <div className="w-full h-[180px] bg-[#005BFF] text-white text-[28px] font-bold flex items-center justify-center rounded-b-[20px] leading-[32px] tracking-[-0.75px] mb-[24px]">
-        처리완료
+        {t('docDetail.completed')}
       </div>
 
       <div className="flex flex-col gap-[20px] px-[20px] pb-[100px]">
-        <SectionCard title="재해자 정보">
+        <SectionCard title={t('docDetail.section.victim')}>
           <InfoList items={jehaejaInfo} />
         </SectionCard>
 
-        <SectionCard title="사업장 정보">
+        <SectionCard title={t('docDetail.section.company')}>
           <InfoList items={companyInfo} />
         </SectionCard>
 
-        <SectionCard title="재해 및 치료 정보">
+        <SectionCard title={t('docDetail.section.injury')}>
           <InfoList items={injuryInfo} />
         </SectionCard>
 
-        <Button text="이전으로" onClick={() => navigate('/doclist')} />
+        <Button
+          text={t('docDetail.back')}
+          onClick={() => navigate('/doclist')}
+        />
       </div>
     </>
   );

--- a/src/pages/docList/DocItem.tsx
+++ b/src/pages/docList/DocItem.tsx
@@ -1,13 +1,13 @@
 import { DocItem } from './InfoList';
 
 export const jehaejaInfo: DocItem[] = [
-  { label: '이름', value: '김성헌' },
-  { label: '외국인등록번호', value: '111111-111111' },
-  { label: '연락처', value: '010-1111-1111' },
-  { label: '성별', value: '남자' },
-  { label: '근로자유형', value: '근로자' },
+  { label: 'docDetail.label.name', value: '김성헌' },
+  { label: 'docDetail.label.id', value: '111111-111111' },
+  { label: 'docDetail.label.phone', value: '010-1111-1111' },
+  { label: 'docDetail.label.gender', value: '남자' },
+  { label: 'docDetail.label.workerType', value: '근로자' },
   {
-    label: '거주지',
+    label: 'docDetail.label.address',
     value: (
       <>
         서울특별시 광진구 <br /> 화양동 10-29
@@ -17,13 +17,13 @@ export const jehaejaInfo: DocItem[] = [
 ];
 
 export const companyInfo: DocItem[] = [
-  { label: '사업장관리번호', value: '김성헌' },
-  { label: '주소', value: '11111-111111' },
-  { label: '연락처', value: '010-1111-1111' },
-  { label: '사업주명', value: '남자' },
-  { label: '사업장명', value: '근로자' },
+  { label: 'docDetail.label.companyId', value: '김성헌' },
+  { label: 'docDetail.label.address', value: '11111-111111' },
+  { label: 'docDetail.label.phone', value: '010-1111-1111' },
+  { label: 'docDetail.label.ceo', value: '남자' },
+  { label: 'docDetail.label.companyName', value: '근로자' },
   {
-    label: '주소',
+    label: 'docDetail.label.address',
     value: (
       <>
         서울특별시 광진구 <br /> 화양동 10-29
@@ -33,13 +33,13 @@ export const companyInfo: DocItem[] = [
 ];
 
 export const injuryInfo: DocItem[] = [
-  { label: '유형', value: '업무상 사고' },
-  { label: '발생일시', value: '25.02.21' },
-  { label: '다친 부위', value: '010-1111-1111' },
-  { label: '의료기관', value: '서울병원' },
-  { label: '치료 구분', value: '통원' },
+  { label: 'docDetail.label.type', value: '업무상 사고' },
+  { label: 'docDetail.label.date', value: '25.02.21' },
+  { label: 'docDetail.label.part', value: '왼쪽 손가락' },
+  { label: 'docDetail.label.hospital', value: '서울병원' },
+  { label: 'docDetail.label.treatmentType', value: '통원' },
   {
-    label: '재해발생 경위',
+    label: 'docDetail.label.detail',
     value: (
       <>
         서울특별시 광진구 <br /> 화양동 10-29

--- a/src/pages/docList/InfoList.tsx
+++ b/src/pages/docList/InfoList.tsx
@@ -1,23 +1,27 @@
-import { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const InfoList = ({ items }: { items: DocItem[] }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-[20px] text-[17px] leading-[22px]">
+      {items.map((item, idx) => (
+        <div key={idx} className="flex justify-between items-start">
+          <span className="text-[#005BFF] font-medium whitespace-nowrap">
+            {t(item.label)}
+          </span>
+          <span className="text-[#191B1C] text-right max-w-[70%] break-words">
+            {item.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export interface DocItem {
   label: string;
-  value: string | ReactNode;
+  value: string | React.ReactNode;
 }
-
-const InfoList = ({ items }: { items: DocItem[] }) => (
-  <div className="flex flex-col gap-[20px] text-[17px] leading-[22px]">
-    {items.map((item, idx) => (
-      <div key={idx} className="flex justify-between items-start">
-        <span className="text-[#005BFF] font-medium whitespace-nowrap">
-          {item.label}
-        </span>
-        <span className="text-[#191B1C] text-right max-w-[70%] break-words">
-          {item.value}
-        </span>
-      </div>
-    ))}
-  </div>
-);
 
 export default InfoList;


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #61 

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

전자문서 상세페이지 한국어, 영어, 베트남어, 중국어 구현 완료

## 💬 리뷰 요구사항(선택)