### PR TITLE
🔧 [Chore] 빌드 오류 우회 목적으로 tsc 타입 검사 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #69 

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

빌드 오류 우회 목적으로 tsc 타입 검사 제거
- package.json의 build 스크립트에서 `tsc -b` 삭제
- Vite 빌드만 사용하여 타입 에러 무시
- 배포 테스트 목적의 임시 조치이며 추후 되돌릴 예정

## 💬 리뷰 요구사항(선택)