### PR TITLE
✨ [Feat] 리프레쉬 토큰 api 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import HosList from './pages/result/KakaoMap/HosList';
 import DocDetail from './pages/docList/DocDetail';
 import MyPage from './pages/mypage/MyPage';
 import './i18n';
+import { useEffect } from 'react';
+
 function FooterCondition() {
   const location = useLocation();
   const hideFooterPaths = ['/', '/add', '/chat', '/language'];
@@ -31,6 +33,20 @@ function FooterCondition() {
 const queryClient = new QueryClient();
 
 function App() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const accessToken = params.get('accessToken');
+    const refreshToken = params.get('refreshToken');
+
+    if (accessToken) {
+      localStorage.setItem('accessToken', accessToken);
+      if (refreshToken) localStorage.setItem('refreshToken', refreshToken);
+
+      const cleanUrl = window.location.origin + window.location.pathname;
+      window.history.replaceState({}, document.title, cleanUrl);
+    }
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <Router>

--- a/src/pages/language/Language.tsx
+++ b/src/pages/language/Language.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '@/components/Header';
@@ -20,16 +20,6 @@ const Language = () => {
   const [language, setLanguage] = useState<string | null>(null);
   const { i18n } = useTranslation();
   const navigate = useNavigate();
-
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const token = params.get('accessToken');
-    console.log('📦 저장된 accessToken:', token);
-
-    if (token) {
-      localStorage.setItem('accessToken', token);
-    }
-  }, []);
 
   const handleClick = () => {
     if (!language) return;


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #83 

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] axios 인터셉터에 토큰 만료 시 자동 재발급 처리 로직 추가
- [x] 401 → 406 응답 시 refreshToken을 POST /auth/refresh에 전송
- [x] 재발급 받은 accessToken, refreshToken을 localStorage에 갱신
- [x] 기존 요청에 새 accessToken을 적용해 재시도 처리
- [x] 재발급 실패 시 로그인 페이지로 이동하도록 예외 처리

## 💬 리뷰 요구사항(선택)