### PR TITLE
✨ [feat] 문서 상세보기 api 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ function App() {
               <Route path="/doclist" element={<DocList />} />
               <Route path="/doc" element={<FormStepper />} />
               <Route path="/hoslist" element={<HosList />} />
-              <Route path="/docdetail" element={<DocDetail />} />
+              <Route path="/docdetail/:documentId" element={<DocDetail />} />
               <Route path="/mypage" element={<MyPage />} />
             </Routes>
           </div>

--- a/src/apis/doc.tsx
+++ b/src/apis/doc.tsx
@@ -36,3 +36,9 @@ export const patchDocStatus = async ({
   });
   return response.data;
 };
+
+export const getDocDetail = async (documentId: string) => {
+  const response = await api.get(`/document/detail/${documentId}`);
+  console.log(response.data);
+  return response.data;
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,7 +16,7 @@ const Footer = () => {
 
   const handleClick = (menu: string) => {
     if (menu === 'home') {
-      navigate('/');
+      navigate('/home');
     } else if (menu === 'chatlist') {
       navigate('/chatlist');
     } else if (menu === 'doclist') {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -219,7 +219,8 @@
       "part": "다친 부위",
       "hospital": "의료기관",
       "treatmentType": "치료 구분",
-      "detail": "재해발생 경위"
+      "detail": "재해발생 경위",
+      "businessType": "업종명"
     }
   },
   "result": {

--- a/src/pages/docList/DocBox.tsx
+++ b/src/pages/docList/DocBox.tsx
@@ -4,15 +4,21 @@ import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { getDocList } from '@/apis/doc';
 import { DocListResponse, DocumentStatusResponse } from '@/types/doc';
 import { patchDocStatus } from '@/apis/doc';
+import { useNavigate } from 'react-router-dom';
 
 const DocBox = () => {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const { data: docListData } = useQuery<DocListResponse>({
     queryKey: ['docList'],
     queryFn: getDocList,
   });
+
+  const handleNavigate = (docPk: number) => {
+    navigate(`/docdetail/${docPk}`);
+  };
 
   const mutation = useMutation({
     mutationFn: patchDocStatus,
@@ -47,14 +53,21 @@ const DocBox = () => {
           docListData.data.map((doc) => {
             const isSuccess = doc.docWhether;
             return (
-              <Box key={doc.docPk} className="flex gap-4 h-20">
+              <Box
+                key={doc.docPk}
+                className="flex gap-4 h-20 cursor-pointer"
+                onClick={() => handleNavigate(doc.docPk)}
+              >
                 <div className="flex flex-col flex-[7] items-start justify-center p-4">
                   <p className="font-semibold text-[18px]">{doc.disaster}</p>
                   <p className="line-clamp-1 font-semibold text-sm text-mainGray">
                     {doc.docDisasterDate}
                   </p>
                 </div>
-                <div className="flex flex-[3] p-4 justify-end items-center">
+                <div
+                  className="flex flex-[3] p-4 justify-end items-center"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <button
                     onClick={() => handleClick(doc.docPk)}
                     className={`${

--- a/src/pages/docList/DocDetail.tsx
+++ b/src/pages/docList/DocDetail.tsx
@@ -1,13 +1,87 @@
 import Button from '@/components/Button';
 import SectionCard from './SectionCard';
 import InfoList from './InfoList';
-import { companyInfo, injuryInfo, jehaejaInfo } from './DocItem';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { getDocDetail } from '@/apis/doc';
+import { useQuery } from '@tanstack/react-query';
 
 const DocDetail = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { documentId } = useParams<{ documentId: string }>();
+
+  const { data } = useQuery({
+    queryKey: ['docDetail', documentId],
+    queryFn: () => getDocDetail(documentId!),
+    enabled: !!documentId,
+  });
+
+  const detail = data?.data;
+
+  const mappedVictimInfo = detail
+    ? [
+        { label: 'docDetail.label.name', value: detail.userName },
+        { label: 'docDetail.label.id', value: detail.userRegisterNm },
+        { label: 'docDetail.label.phone', value: detail.docCompanyPhoneNm },
+        {
+          label: 'docDetail.label.gender',
+          value: detail.userGender === 'MALE' ? '남자' : '여자',
+        },
+        { label: 'docDetail.label.workerType', value: detail.docType },
+        {
+          label: 'docDetail.label.address',
+          value: (
+            <>
+              {detail.userAddress
+                .split(' ')
+                .map((line: string, idx: number) => (
+                  <span key={idx}>
+                    {line}
+                    <br />
+                  </span>
+                ))}
+            </>
+          ),
+        },
+      ]
+    : [];
+
+  const mappedCompanyInfo = detail
+    ? [
+        { label: 'docDetail.label.companyName', value: detail.docCompanyNm },
+        { label: 'docDetail.label.address', value: detail.docCompanyAddress },
+        { label: 'docDetail.label.phone', value: detail.docCompanyPhoneNm },
+        { label: 'docDetail.label.ceo', value: detail.docOwnerName },
+        {
+          label: 'docDetail.label.businessType',
+          value: detail.docBusinessName,
+        },
+      ]
+    : [];
+
+  const mappedInjuryInfo = detail
+    ? [
+        { label: 'docDetail.label.type', value: detail.disaster },
+        { label: 'docDetail.label.date', value: detail.docDisasterDate },
+        { label: 'docDetail.label.part', value: detail.docInjury },
+        { label: 'docDetail.label.hospital', value: detail.docHospital },
+        { label: 'docDetail.label.treatmentType', value: detail.therapy },
+        {
+          label: 'docDetail.label.detail',
+          value: (
+            <>
+              {detail.docReason.split(' ').map((line: string, idx: number) => (
+                <span key={idx}>
+                  {line}
+                  <br />
+                </span>
+              ))}
+            </>
+          ),
+        },
+      ]
+    : [];
 
   return (
     <>
@@ -17,15 +91,15 @@ const DocDetail = () => {
 
       <div className="flex flex-col gap-[20px] px-[20px] pb-[100px]">
         <SectionCard title={t('docDetail.section.victim')}>
-          <InfoList items={jehaejaInfo} />
+          <InfoList items={mappedVictimInfo} />
         </SectionCard>
 
         <SectionCard title={t('docDetail.section.company')}>
-          <InfoList items={companyInfo} />
+          <InfoList items={mappedCompanyInfo} />
         </SectionCard>
 
         <SectionCard title={t('docDetail.section.injury')}>
-          <InfoList items={injuryInfo} />
+          <InfoList items={mappedInjuryInfo} />
         </SectionCard>
 
         <Button

--- a/src/pages/docList/InfoList.tsx
+++ b/src/pages/docList/InfoList.tsx
@@ -10,7 +10,7 @@ const InfoList = ({ items }: { items: DocItem[] }) => {
           <span className="text-[#005BFF] font-medium whitespace-nowrap">
             {t(item.label)}
           </span>
-          <span className="text-[#191B1C] text-right max-w-[70%] break-words">
+          <span className="text-[#191B1C] text-right whitespace-pre-wrap break-keep">
             {item.value}
           </span>
         </div>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #96 

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Header에 홈 누르면 /home으로 가게 navigate 부분을 수정 하였습니다.
- 문서 상세보기 api를 연결하여 만든 문서를 불러오게 구현 하였습니다.

## 💬 리뷰 요구사항(선택)